### PR TITLE
Fix memory leak on object and associative array processing

### DIFF
--- a/src/amf0.c
+++ b/src/amf0.c
@@ -237,6 +237,7 @@ static amf0_data * amf0_object_read(read_proc_t read_proc, void * user_data) {
                         amf0_data_free(data);
                         return NULL;
                     }
+                    amf0_data_free(name);
                 }
                 else {
                     amf0_data_free(name);
@@ -278,6 +279,7 @@ static amf0_data * amf0_associative_array_read(read_proc_t read_proc, void * use
                         amf0_data_free(name);
                         break;
                     }
+                    amf0_data_free(name);
                 }
                 else {
                     /* invalid name: error */


### PR DESCRIPTION
Names allocated with `amf0_string_read` inside `amf0_associative_array_read` and `amf0_object_read` are never freed.

The names in question are only used as `(char *)amf0_string_get_uint8_ts(name)`, are copied inside `amf0_object_add` with `amf0_str`, and are safe to free after `amf0_object_add` is done with them.

The same goes for `amf0_associative_array_read`.
